### PR TITLE
fix: quickstart smoke-test reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,18 @@ For OpenAI-compatible or custom providers, set `OPENAI_API_KEY` / `OPENAI_BASE_U
 
 ### Run Evaluation
 
+Before the first run, build the default Docker harness image:
+
+```bash
+docker build -f docker/Dockerfile.pawbench-qwenpaw -t qwenclawbench-qwenpaw:latest .
+```
+
 ```bash
 # Smoke test: run one PawBench v1.0 task with the default qwenpaw harness
-python run_bench.py --tasks T001 --model openai/gpt-4o
+python run_bench.py --tasks T053 --model dashscope/qwen3.6-plus
 
 # Pick a different harness
-python run_bench.py --agents openclaw --tasks T001 --model dashscope/qwen3.6-plus
+python run_bench.py --agents openclaw --tasks T053 --model dashscope/qwen3.6-plus
 
 # Compare harnesses on a task subset
 python run_bench.py \
@@ -90,7 +96,7 @@ python run_bench.py \
 
 # Sequentially evaluate multiple models
 python run_bench.py \
-  --model openai/gpt-4o \
+  --model dashscope/qwen3.6-plus \
   --model anthropic/claude-sonnet-4-6
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -75,12 +75,18 @@ EOF
 
 ### 运行评测
 
+首次运行前，先构建默认的 Docker harness 镜像：
+
+```bash
+docker build -f docker/Dockerfile.pawbench-qwenpaw -t qwenclawbench-qwenpaw:latest .
+```
+
 ```bash
 # Smoke test：用默认 qwenpaw harness 跑一个 PawBench v1.0 任务
-python run_bench.py --tasks T001 --model openai/gpt-4o
+python run_bench.py --tasks T053 --model dashscope/qwen3.6-plus
 
 # 切换 Harness
-python run_bench.py --agents openclaw --tasks T001 --model dashscope/qwen3.6-plus
+python run_bench.py --agents openclaw --tasks T053 --model dashscope/qwen3.6-plus
 
 # 在指定任务集上横向对比多个 Harness
 python run_bench.py \
@@ -90,7 +96,7 @@ python run_bench.py \
 
 # 顺序评测多个模型
 python run_bench.py \
-  --model openai/gpt-4o \
+  --model dashscope/qwen3.6-plus \
   --model anthropic/claude-sonnet-4-6
 ```
 

--- a/pawbench/backend.py
+++ b/pawbench/backend.py
@@ -164,11 +164,19 @@ class PawBenchBackend(BenchmarkBackend):
         loader = TaskLoader(tasks_dir)
         tasks = loader.load_all_tasks()
         if task_filter:
-            tasks = [
-                t for t in tasks
-                if t.task_id in task_filter
-                or any(t.task_id.startswith(f) for f in task_filter)
-            ]
+            def _matches(t: Any, filters: list[str]) -> bool:
+                file_stem = t.file_path.stem if t.file_path else ""
+                for f in filters:
+                    if t.task_id == f:
+                        return True
+                    if t.task_id.startswith(f):
+                        return True
+                    # Also match by filename stem (e.g. "--tasks T053" matches
+                    # T053_pinchbench_blog.md regardless of the `id:` front-matter value)
+                    if file_stem == f or file_stem.startswith(f):
+                        return True
+                return False
+            tasks = [t for t in tasks if _matches(t, task_filter)]
         return tasks
 
     def run_and_grade(


### PR DESCRIPTION
Three issues found while end-to-end testing the README quickstart:

1. README was missing the Docker build step before first run — add it to both README.md and README.zh-CN.md so users know to build qwenclawbench-qwenpaw:latest before calling run_bench.py.

2. backend.py task filter only matched on task_id (YAML front-matter id:), so --tasks T053 could not find tasks whose id is e.g. task_blog. Extend the filter to also match against the file stem so T-number prefixes (T001, T053 ...) work regardless of the id field value.

3. Quickstart smoke-test used openai/gpt-4o but .env routes openai/* to DashScope which does not serve gpt-4o, causing SHORT_TRANSCRIPT failures. Switch all examples to dashscope/qwen3.6-plus and update the default smoke-test task from T001 to T053.