### PR TITLE
fix(qwenpaw): honor custom OpenAI base URL

### DIFF
--- a/pawbench/agents/impl/qwenpaw_agent.py
+++ b/pawbench/agents/impl/qwenpaw_agent.py
@@ -318,6 +318,14 @@ try:
 except Exception:
     pass  # monkey-patch is optional; skip if qwenpaw internals changed
 
+# ── monkey-patch: allow custom base_url for builtin OpenAI provider ─────────
+try:
+    import qwenpaw.providers.provider_manager as _qw_provider_manager
+
+    _qw_provider_manager.PROVIDER_OPENAI.freeze_url = False
+except Exception:
+    pass  # monkey-patch is optional; skip if qwenpaw internals changed
+
 # ── start qwenpaw app ──────────────────────────────────────────────────────
 sys.argv = ["qwenpaw", "app", "--host", "127.0.0.1", "--port", "8088"]
 from qwenpaw.__main__ import cli  # noqa: E402


### PR DESCRIPTION
## Summary

Fix qwenpaw benchmark runs against custom OpenAI-compatible endpoints.

QwenPaw's builtin `openai` provider has `freeze_url=True`, so configuring
`base_url` through the provider API is ignored and requests continue to target
`https://api.openai.com/v1`. This causes custom endpoints passed via
`--base-url` to time out before the agent can produce tool calls.

This patch allows the builtin OpenAI provider to accept a custom `base_url`
inside the benchmark startup shim.

## Verification

- `python -m py_compile pawbench/agents/impl/qwenpaw_agent.py`
- Ran:
  `python run_bench.py --agents qwenpaw --model Qwen3.6-35B-A3B --base-url http://xxx.xxx.xxx.xxx:xxxxx/v1 --save-workspace --verbose --tasks 3d-scan-calc --max-retries 1`
- Result: generated `mass_report.json`, automated tests passed, score `0.926/1.00`