### PR TITLE
fix(agents): propagate runtime config to agent instances

### DIFF
--- a/pawbench/agents/factory.py
+++ b/pawbench/agents/factory.py
@@ -30,6 +30,17 @@ class AgentFactory:
 
     # Populated lazily to avoid import-time circular dependencies.
     _REGISTRY: "dict[str, tuple[type, str]]" = {}
+    _AGENT_RUNTIME_CONFIG_KEYS = (
+        "generate_kwargs",
+        "max_tokens",
+        "max_turns",
+        "qwenpaw_version",
+        "skip_bootstrap",
+        "task_timeout_s",
+        "thinking",
+        "thinking_level",
+        "vision_model",
+    )
 
     @classmethod
     def _populate(cls) -> None:
@@ -56,14 +67,18 @@ class AgentFactory:
                 f"Known types: {list(cls._REGISTRY)}"
             )
         AgentCls, _ = entry
-        return AgentCls(
-            model=agent_config["model"],
-            api_key=agent_config.get("api_key") or os.environ.get("OPENAI_API_KEY", ""),
-            base_url=agent_config.get("base_url") or os.environ.get(
+        kwargs = {
+            "model": agent_config["model"],
+            "api_key": agent_config.get("api_key") or os.environ.get("OPENAI_API_KEY", ""),
+            "base_url": agent_config.get("base_url") or os.environ.get(
                 "OPENAI_BASE_URL", "https://api.openai.com/v1"
             ),
-            api_model_name=agent_config.get("api_model_name"),
-        )
+            "api_model_name": agent_config.get("api_model_name"),
+        }
+        for key in cls._AGENT_RUNTIME_CONFIG_KEYS:
+            if key in agent_config:
+                kwargs[key] = agent_config[key]
+        return AgentCls(**kwargs)
 
     @classmethod
     def default_image_for_type(cls, agent_type: str) -> str:

--- a/run_bench.py
+++ b/run_bench.py
@@ -173,7 +173,7 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         default=False,
         dest="skip_bootstrap",
-        help="[openclaw] Remove BOOTSTRAP.md / SOUL.md from the task workspace before execution.",
+        help="[QwenPaw] Remove BOOTSTRAP.md from the task workspace before execution.",
     )
 
     model_grp = p.add_argument_group("Model & API configuration")


### PR DESCRIPTION
## Summary

- Propagate selected runtime agent config from `AgentFactory.create()` into agent instances.
- Fix `task_timeout_s` not reaching QwenPaw, Hermes, and OpenClaw, which caused agent-level commands to fall back to the 1800s default instead of each task's configured timeout.
- Update the `--skip-bootstrap` CLI help text to match the actual QwenPaw behavior.

## Details

`PawBenchBackend.run_and_grade()` computes `task_timeout_s` from each task's `timeout_seconds`, but `AgentFactory.create()` previously only passed model/API fields into the agent constructor. As a result, agent implementations reading `self.config["task_timeout_s"]` never received the value.

This change forwards a small whitelist of agent runtime config keys, including `task_timeout_s`, `thinking_level`, and QwenPaw/Hermes/OpenClaw-specific options, while keeping judge configuration out of agent instances.

## Verification

- `python -m compileall pawbench/agents/factory.py run_bench.py`