### PR TITLE
Fix hidden PDDL grader dependencies

### DIFF
--- a/data/pawbench-v1.0/tasks/T136_skillsbench_pddl-tpp-planning.md
+++ b/data/pawbench-v1.0/tasks/T136_skillsbench_pddl-tpp-planning.md
@@ -211,16 +211,17 @@ def grade(transcript: list, workspace_path: str) -> dict:
         return scores
 
     try:
-        subprocess.run(
-            [sys.executable, "-m", "pip", "install", "--quiet",
-             "--disable-pip-version-check", "pytest", "unified-planning", "up-pyperplan"],
-            check=True, capture_output=True, timeout=180,
-        )
+        import pytest  # noqa: F401
+        import up_pyperplan  # noqa: F401
+        from unified_planning.io import PDDLReader  # noqa: F401
+        from unified_planning.shortcuts import OneshotPlanner  # noqa: F401
     except Exception:  # noqa: BLE001
         try:
-            import pytest  # noqa: F401
-            from unified_planning.io import PDDLReader  # noqa: F401
-            from unified_planning.shortcuts import OneshotPlanner  # noqa: F401
+            subprocess.run(
+                [sys.executable, "-m", "pip", "install", "--quiet",
+                 "--disable-pip-version-check", "pytest", "unified-planning", "up-pyperplan"],
+                check=True, capture_output=True, timeout=180,
+            )
         except Exception:  # noqa: BLE001
             return scores
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,8 @@ numpy>=1.24.0
 pandas>=2.0.0
 cvxpy>=1.4.0
 openpyxl>=3.1.0
+unified-planning==1.3.0
+up-pyperplan==1.1.0
 
 # External tools required at runtime (not pip-installable):
 #   docker   — Docker CLI must be available in PATH

--- a/tests/test_grader_dependencies.py
+++ b/tests/test_grader_dependencies.py
@@ -1,0 +1,78 @@
+import ast
+import re
+from pathlib import Path
+
+from pawbench.task_loader import TaskLoader
+from unified_planning.io import PDDLReader
+from unified_planning.shortcuts import OneshotPlanner, get_environment
+
+ROOT = Path(__file__).resolve().parents[1]
+PYTHON_BLOCK_RE = re.compile(r"```python\s*\n(.*?)\n\s*```", re.DOTALL)
+DISTRIBUTION_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9._-]*)")
+
+
+def test_embedded_grader_dependencies_are_declared() -> None:
+    requirements = _requirements_distributions(ROOT / "requirements.txt")
+    tasks_dir = ROOT / "data" / "pawbench-v1.0" / "tasks"
+    tasks = TaskLoader(tasks_dir).load_all_tasks()
+
+    declared_by_graders = {
+        package
+        for task in tasks
+        for package in _grader_python_packages(task.automated_checks or "")
+    }
+
+    assert declared_by_graders <= requirements, (
+        "Embedded automated checkers use undeclared Python packages: "
+        f"{sorted(declared_by_graders - requirements)}"
+    )
+
+
+def test_t136_pyperplan_dependency_can_solve_fixture() -> None:
+    get_environment().credits_stream = None
+    fixture_dir = ROOT / "data" / "pawbench-v1.0" / "assets" / "T136_skillsbench_pddl-tpp-planning" / "tpp"
+    problem = PDDLReader().parse_problem(fixture_dir / "domain.pddl", fixture_dir / "task01.pddl")
+
+    with OneshotPlanner(name="pyperplan") as planner:
+        result = planner.solve(problem)
+
+    assert result.plan is not None
+    assert result.plan.actions
+
+
+def _requirements_distributions(path: Path) -> set[str]:
+    packages: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        match = DISTRIBUTION_RE.match(line)
+        if match:
+            packages.add(match.group(1))
+    return packages
+
+
+def _grader_python_packages(automated_checks: str) -> set[str]:
+    match = PYTHON_BLOCK_RE.search(automated_checks)
+    if not match:
+        return set()
+    tree = ast.parse(match.group(1))
+    packages: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        command = node.args[0]
+        if not isinstance(command, (ast.List, ast.Tuple)):
+            continue
+        values = [
+            item.value
+            for item in command.elts
+            if isinstance(item, ast.Constant) and isinstance(item.value, str)
+        ]
+        try:
+            install_index = values.index("install")
+        except ValueError:
+            continue
+        if "pip" not in values[:install_index]:
+            continue
+        packages.update(value for value in values[install_index + 1 :] if not value.startswith("-"))
+    return packages


### PR DESCRIPTION
## Summary

- Declare T136's `unified-planning` and `up-pyperplan` dependencies in the top-level grader requirements.
- Pin planner versions so Docker-produced plan pickles and host-side grading use compatible implementations.
- Check installed dependencies before attempting the T136 compatibility install.
- Add regression coverage for embedded grader dependencies and a real pyperplan solve using the bundled T136 fixture.

## Problem

T136 is marked as a closed task with `external_dependency: none`, but its embedded grader previously depended on a runtime PyPI installation:

- `unified-planning`
- `up-pyperplan`

These packages were missing from the top-level `requirements.txt`. If the dynamic installation failed because of network, permissions, or environment restrictions, the checker returned all-zero automated scores. This conflated grader setup failures with agent performance.

The supplied `solve.py` also uses these packages inside the agent runtime. All PawBench Dockerfiles install the top-level requirements, so declaring them there keeps the runtime and host grader environments aligned.

## Changes

- Add:
  - `unified-planning==1.3.0`
  - `up-pyperplan==1.1.0`
- Change T136 grading to import-check dependencies first and only use dynamic installation as a compatibility fallback.
- Add a test that:
  - Ensures packages explicitly installed by embedded graders are declared in `requirements.txt`.
  - Verifies pyperplan can solve the bundled `task01.pddl` fixture.

## Validation

```bash
ruff check tests/test_grader_dependencies.py
PYTHONPATH=. python -m pytest tests -q