### PR TITLE
Fix numeric task filters selecting multiple tasks

### DIFF
--- a/pawbench/backend.py
+++ b/pawbench/backend.py
@@ -172,11 +172,18 @@ class PawBenchBackend(BenchmarkBackend):
                 for f in filters:
                     if t.task_id == f:
                         return True
-                    if t.task_id.startswith(f):
+                    if file_stem == f:
                         return True
-                    # Also match by filename stem (e.g. "--tasks T053" matches
-                    # T053_pinchbench_blog.md regardless of the `id:` front-matter value)
-                    if file_stem == f or file_stem.startswith(f):
+                    # Bare benchmark indices select by filename, not by a legacy
+                    # task ID that happens to share the same prefix. For example,
+                    # T150 must select T150_wildclawbench_..., not also the task
+                    # whose front-matter ID is T150_project_progress_report.
+                    if re.fullmatch(r"T\d+", f):
+                        if file_stem.startswith(f"{f}_"):
+                            return True
+                        continue
+                    # Preserve prefix matching for descriptive selectors.
+                    if t.task_id.startswith(f) or file_stem.startswith(f):
                         return True
                 return False
             tasks = [t for t in tasks if _matches(t, task_filter)]

--- a/tests/test_backend_task_filtering.py
+++ b/tests/test_backend_task_filtering.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import pytest
+
+from pawbench.backend import PawBenchBackend
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize("selector", ["T002", "T150"])
+def test_numeric_task_filter_selects_filename_index_only(selector):
+    tasks = PawBenchBackend(ROOT).load_tasks([selector])
+
+    assert len(tasks) == 1
+    assert tasks[0].file_path.stem.startswith(f"{selector}_")
+
+
+def test_full_legacy_task_id_remains_selectable():
+    tasks = PawBenchBackend(ROOT).load_tasks(["T150_project_progress_report"])
+
+    assert [task.task_id for task in tasks] == ["T150_project_progress_report"]


### PR DESCRIPTION
`--tasks T150` currently selects two tasks: the actual `T150_...` task and `T041_claweval_T150_project_progress_report`, because the latter has a task ID starting with `T150`.

The same issue exists for selectors such as `T002`.

This change treats a bare `T###` selector as a filename index, while keeping exact legacy task IDs and descriptive prefix matching working as before. I also added regression tests for `T002`, `T150`, and the full `T150_project_progress_report` ID.

Tested with:

```bash
python -m pytest -q tests/test_backend_task_filtering.py
```
